### PR TITLE
Fixed support for npm 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,19 +14,23 @@
     "eslint",
     "eslintconfig"
   ],
-  "author": "Jake Teton-Landis <Akkuma> (https://twitter.com/@jitl)",
+  "author": "Gregory Waxman",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/virtru/lint-trap/issues"
   },
   "homepage": "https://github.com/virtru/lint-trap#readme",
   "dependencies": {
-    "eslint-plugin-virtru-lint": "virtru/eslint-plugin-virtru-lint",
-    "semver": "^5.1.0",
+    "eslint": "^2.11.1",
     "eslint-config-airbnb-base": "^3.0.1",
-    "eslint-plugin-import": "^1.8.1"
+    "eslint-plugin-import": "^1.8.1",
+    "eslint-plugin-virtru-lint": "virtru/eslint-plugin-virtru-lint",
+    "semver": "^5.1.0"
   },
   "peerDependencies": {
-    "eslint": "^2.11.1"
+    "eslint": "^2.11.1",
+    "eslint-config-airbnb-base": "^3.0.1",
+    "eslint-plugin-import": "^1.8.1",
+    "eslint-plugin-virtru-lint": "virtru/eslint-plugin-virtru-lint"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-lint-trap",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A fork of AirBnB's eslint config for use at Virtru",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
By listing dependencies in peer and regular deps, we support npm 3's flat hierarchy w/deps and peer dependency resolves npm2's non-flattening behaviour.

NPM 2 will pull in peerDeps by default, NPM 3 just checks that you have peerDeps and with flattening you'll have it in the correct top directory.
