### PR TITLE
Removed eslint-plugin-virtru-lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "peerDependencies": {
     "eslint": "^2.11.1",
     "eslint-config-airbnb-base": "^3.0.1",
-    "eslint-plugin-import": "^1.8.1",
-    "eslint-plugin-virtru-lint": "virtru/eslint-plugin-virtru-lint"
+    "eslint-plugin-import": "^1.8.1"
   }
 }


### PR DESCRIPTION
We misused it as a direct dependency in repos, rather than a peerDependency of lint-trap.
