### PR TITLE
Linting enforcement preparation

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -2,12 +2,12 @@
 
 module.exports = {
   extends: 'airbnb-base/legacy',
-  'env': {                           // http://eslint.org/docs/user-guide/configuring.html#specifying-environments
-    'browser': true,                 // browser global variables
-    'node': true,                    // Node.js global variables and Node.js-specific rules
-    'es6': true
+  env: {                           
+    browser: true, // Browser global variables
+    node: true, // Node.js global variables and Node.js-specific rules
+    es6: true
   },
-  'plugins': [
+  plugins: [
     'virtru-lint'
   ],
 
@@ -32,14 +32,15 @@ module.exports = {
   },
 */
 
-  'rules': {
+  rules: { // See http://eslint.org/docs/rules/
     /**
-     * Values:
+     * Values (see http://eslint.org/docs/user-guide/configuring):
      *  0 = Rule turned off
      *  1 = Warn
      *  2 = Error
      *
-     * See http://eslint.org/docs/user-guide/configuring
+     * Docs for a rule, %s, are found at http://eslint.org/docs/rules/%s
+     *  Example: http://eslint.org/docs/rules/no-shadow
      */
 
     /**
@@ -52,7 +53,7 @@ module.exports = {
      */
     //@TODO: We aren't using babel at the moment.
     //babel inserts 'use strict'; for us
-    //'strict': [2, 'never'],          // http://eslint.org/docs/rules/strict
+    //'strict': [2, 'never'],          
 
     /**
      * Virtru Specific Rules
@@ -63,114 +64,114 @@ module.exports = {
      * ES6
      */
 /*
-    'no-var': 2,                     // http://eslint.org/docs/rules/no-var
-    'prefer-const': 2,               // http://eslint.org/docs/rules/prefer-const
+    'no-var': 2,                     
+    'prefer-const': 2,               
 */
     /**
      * Variables
      */
-    'no-shadow': [2, {               // http://eslint.org/docs/rules/no-shadow
+    'no-shadow': [2, {               
       allow: ['res', 'req', 'err', 'next', 'resolve', 'reject', 'done', 'cb']
     }],
-    'no-unused-vars': [2, {          // http://eslint.org/docs/rules/no-unused-vars
+    'no-unused-vars': [2, {          
       'vars': 'all',
       'args': 'none'
     }],
-    'no-use-before-define': [2, 'nofunc'],       // http://eslint.org/docs/rules/no-use-before-define
+    'no-use-before-define': [2, 'nofunc'],       
 
     /**
      * Possible errors
      */
-    'comma-dangle': [2, 'only-multiline'],    // http://eslint.org/docs/rules/comma-dangle  @TODO: Turn into separate for front/back in dev env
-    'no-cond-assign': [2, 'except-parens'], // http://eslint.org/docs/rules/no-cond-assign
-    //'no-console': 1,                 // http://eslint.org/docs/rules/no-console
-    'no-debugger': 1,                // http://eslint.org/docs/rules/no-debugger
-    'no-alert': 2,                   // http://eslint.org/docs/rules/no-alert
-    //'no-constant-condition': 1,      // http://eslint.org/docs/rules/no-constant-condition
-    //'no-dupe-keys': 2,               // http://eslint.org/docs/rules/no-dupe-keys
-    //'no-duplicate-case': 2,          // http://eslint.org/docs/rules/no-duplicate-case
-    //'no-empty': 2,                   // http://eslint.org/docs/rules/no-empty
-    //'no-ex-assign': 2,               // http://eslint.org/docs/rules/no-ex-assign
-    'no-extra-boolean-cast': 2,      // http://eslint.org/docs/rules/no-extra-boolean-cast
-    'no-extra-parens': [2, 'functions'], // http://eslint.org/docs/rules/no-extra-parens
-    //'no-extra-semi': 2,              // http://eslint.org/docs/rules/no-extra-semi
-    //'no-func-assign': 2,             // http://eslint.org/docs/rules/no-func-assign
-    //'no-inner-declarations': 2,      // http://eslint.org/docs/rules/no-inner-declarations
-    //'no-invalid-regexp': 2,          // http://eslint.org/docs/rules/no-invalid-regexp
-    //'no-irregular-whitespace': 2,    // http://eslint.org/docs/rules/no-irregular-whitespace
-    //'no-obj-calls': 2,               // http://eslint.org/docs/rules/no-obj-calls
-    //'no-sparse-arrays': 2,           // http://eslint.org/docs/rules/no-sparse-arrays
-    //'no-unreachable': 2,             // http://eslint.org/docs/rules/no-unreachable
-    //'use-isnan': 2,                  // http://eslint.org/docs/rules/use-isnan
+    'comma-dangle': [2, 'only-multiline'],    
+    'no-cond-assign': [2, 'except-parens'], 
+    //'no-console': 1,                 
+    'no-debugger': 1,                
+    'no-alert': 2,                   
+    //'no-constant-condition': 1,      
+    //'no-dupe-keys': 2,               
+    //'no-duplicate-case': 2,          
+    //'no-empty': 2,                   
+    //'no-ex-assign': 2,               
+    'no-extra-boolean-cast': 2,      
+    'no-extra-parens': [2, 'functions'], 
+    //'no-extra-semi': 2,              
+    //'no-func-assign': 2,             
+    //'no-inner-declarations': 2,      
+    //'no-invalid-regexp': 2,          
+    //'no-irregular-whitespace': 2,    
+    //'no-obj-calls': 2,               
+    //'no-sparse-arrays': 2,           
+    //'no-unreachable': 2,             
+    //'use-isnan': 2,                  
     'valid-jsdoc': [1, {requireReturn: false}],
 
     /**
      * Best practices
      */
-    'consistent-return': [1, { treatUndefinedAsUnspecified: true}],          // http://eslint.org/docs/rules/consistent-return
-    //'curly': [2, 'multi-line'],      // http://eslint.org/docs/rules/curly
-    //'default-case': 2,               // http://eslint.org/docs/rules/default-case
-    /*'dot-notation': [2, {            // http://eslint.org/docs/rules/dot-notation
+    'consistent-return': [1, { treatUndefinedAsUnspecified: true}],          
+    //'curly': [2, 'multi-line'],      
+    //'default-case': 2,               
+    /*'dot-notation': [2, {            
       'allowKeywords': true
     }],*/
-    'eqeqeq': 2,                     // http://eslint.org/docs/rules/eqeqeq
-    //'guard-for-in': 2,               // http://eslint.org/docs/rules/guard-for-in
-    //'no-caller': 2,                  // http://eslint.org/docs/rules/no-caller
-    //'no-else-return': 2,             // http://eslint.org/docs/rules/no-else-return
-    'no-eq-null': 2,                 // http://eslint.org/docs/rules/no-eq-null
-    //'no-eval': 2,                    // http://eslint.org/docs/rules/no-eval
-    //'no-extend-native': 2,           // http://eslint.org/docs/rules/no-extend-native
-    //'no-extra-bind': 2,              // http://eslint.org/docs/rules/no-extra-bind
-    //'no-fallthrough': 2,             // http://eslint.org/docs/rules/no-fallthrough
-    //'no-floating-decimal': 2,        // http://eslint.org/docs/rules/no-floating-decimal
-    //'no-implied-eval': 2,            // http://eslint.org/docs/rules/no-implied-eval
-    //'no-lone-blocks': 2,             // http://eslint.org/docs/rules/no-lone-blocks
-    //'no-loop-func': 2,               // http://eslint.org/docs/rules/no-loop-func
-    //'no-multi-str': 2,               // http://eslint.org/docs/rules/no-multi-str
-    //'no-native-reassign': 2,         // http://eslint.org/docs/rules/no-native-reassign
-    //'no-new': 2,                     // http://eslint.org/docs/rules/no-new
-    //'no-new-func': 2,                // http://eslint.org/docs/rules/no-new-func
-    //'no-new-wrappers': 2,            // http://eslint.org/docs/rules/no-new-wrappers
-    //'no-octal': 2,                   // http://eslint.org/docs/rules/no-octal
-    //'no-octal-escape': 2,            // http://eslint.org/docs/rules/no-octal-escape
-    'no-param-reassign': 0,          // http://eslint.org/docs/rules/no-param-reassign
-    //'no-proto': 2,                   // http://eslint.org/docs/rules/no-proto
-    //'no-redeclare': 2,               // http://eslint.org/docs/rules/no-redeclare
-    //'no-return-assign': 2,           // http://eslint.org/docs/rules/no-return-assign
-    //'no-script-url': 2,              // http://eslint.org/docs/rules/no-script-url
-    //'no-self-compare': 2,            // http://eslint.or//g/docs/rules/no-self-compare
-    //'no-sequences': 2,               // http://eslint.org/docs/rules/no-sequences
-    //'no-throw-literal': 2,           // http://eslint.org/docs/rules/no-throw-literal
-    //'no-with': 2,                    // http://eslint.org/docs/rules/no-with
-    //'radix': 2,                      // http://eslint.org/docs/rules/radix
-    'vars-on-top': 0,                // http://eslint.org/docs/rules/vars-on-top
-    'wrap-iife': [2, 'any'],         // http://eslint.org/docs/rules/wrap-iife
-    //'yoda': 2,                       // http://eslint.org/docs/rules/yoda
+    'eqeqeq': 2,                     
+    //'guard-for-in': 2,               
+    //'no-caller': 2,                  
+    //'no-else-return': 2,             
+    'no-eq-null': 2,                 
+    //'no-eval': 2,                    
+    //'no-extend-native': 2,           
+    //'no-extra-bind': 2,              
+    //'no-fallthrough': 2,             
+    //'no-floating-decimal': 2,        
+    //'no-implied-eval': 2,            
+    //'no-lone-blocks': 2,             
+    //'no-loop-func': 2,               
+    //'no-multi-str': 2,               
+    //'no-native-reassign': 2,         
+    //'no-new': 2,                     
+    //'no-new-func': 2,                
+    //'no-new-wrappers': 2,            
+    //'no-octal': 2,                   
+    //'no-octal-escape': 2,            
+    'no-param-reassign': 0,          
+    //'no-proto': 2,                   
+    //'no-redeclare': 2,               
+    //'no-return-assign': 2,           
+    //'no-script-url': 2,              
+    //'no-self-compare': 2,            
+    //'no-sequences': 2,               
+    //'no-throw-literal': 2,           
+    //'no-with': 2,                    
+    //'radix': 2,                      
+    'vars-on-top': 0,                
+    'wrap-iife': [2, 'any'],         
+    //'yoda': 2,                       
 
     /**
      * Style
      */
-    /*'brace-style': [                 // http://eslint.org/docs/rules/brace-style
+    /*'brace-style': [                 
       2,
       '1tbs',
       { 'allowSingleLine': true }
     ],*/
-    'camelcase': [2, {               // http://eslint.org/docs/rules/camelcase
+    'camelcase': [2, {               
       'properties': 'always'
     }],
-    /*'comma-spacing': [2, {           // http://eslint.org/docs/rules/comma-spacing
+    /*'comma-spacing': [2, {           
       'before': false,
       'after': true
     }],*/
-    //'comma-style': [2, 'last'],      // http://eslint.org/docs/rules/comma-style
-    'eol-last': 0,                   // http://eslint.org/docs/rules/eol-last
-    'func-names': 0,                 // http://eslint.org/docs/rules/func-names
-    /*'indent': [                      //http://eslint.org/docs/rules/indent
+    //'comma-style': [2, 'last'],      
+    'eol-last': 0,                   
+    'func-names': 0,                 
+    /*'indent': [                      
       2,
       2,
       { 'SwitchCase': 1 }
     ],*/
-    /*'key-spacing': [2, {             // http://eslint.org/docs/rules/key-spacing
+    /*'key-spacing': [2, {             
         'beforeColon': false,
         'afterColon': true
      }],*/
@@ -179,81 +180,34 @@ module.exports = {
       ignoreComments: false
     }],
     'max-statements': [1, 30],
-    /*'new-cap': [2, {                 // http://eslint.org/docs/rules/new-cap
+    /*'new-cap': [2, {                 
       'newIsCap': true
     }],*/
-    'no-multiple-empty-lines': [1, { // http://eslint.org/docs/rules/no-multiple-empty-lines
+    'no-multiple-empty-lines': [1, { 
       'max': 2
     }],
-    //'no-nested-ternary': 2,          // http://eslint.org/docs/rules/no-nested-ternary
-    //'no-new-object': 2,              // http://eslint.org/docs/rules/no-new-object
-    'no-underscore-dangle': 0,       // http://eslint.org/docs/rules/no-underscore-dangle
-    'object-curly-spacing': [1, 'always'], //http://eslint.org/docs/rules/object-curly-spacing
-    //'one-var': [2, 'never'],         // http://eslint.org/docs/rules/one-var
-    'padded-blocks': [0, 'never'],   // http://eslint.org/docs/rules/padded-blocks
+    //'no-nested-ternary': 2,          
+    //'no-new-object': 2,              
+    'no-underscore-dangle': 0,       
+    'object-curly-spacing': [1, 'always'],
+    //'one-var': [2, 'never'],         
+    'padded-blocks': [0, 'never'],   
     /*'quotes': [
-      2, 'single', {avoidEscape: true}    // http://eslint.org/docs/rules/quotes
+      2, 'single', {avoidEscape: true}    
     ],*/
-    //'semi': [2, 'always'],           // http://eslint.org/docs/rules/semi
-    /*'semi-spacing': [2, {            // http://eslint.org/docs/rules/semi-spacing
+    //'semi': [2, 'always'],           
+    /*'semi-spacing': [2, {            
       'before': false,
       'after': true
     }],*/
-    'space-before-function-paren': [2, 'never'], // http://eslint.org/docs/rules/space-before-function-paren
+    'space-before-function-paren': [2, 'never'], 
     'space-in-parens': [1, 'never'],
-    'space-infix-ops': 2,            // http://eslint.org/docs/rules/space-infix-ops
-    'spaced-comment': [1, 'always',  {// http://eslint.org/docs/rules/spaced-comment
+    'space-infix-ops': 2,            
+    'spaced-comment': [1, 'always',  {
       'exceptions': ['*'],
       'markers': ['@TODO:', '@NOTE:', '@FIXME:', '@HACK:']
     }],
 
-/**
- * JSX style
- */
-    /*
-    'react/display-name': 0,         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/display-name.md
-    'react/jsx-boolean-value': 2,    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md
-    'react/jsx-quotes': [2, 'double'], // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-quotes.md
-    'react/jsx-no-undef': 2,         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-undef.md
-    'react/jsx-sort-props': 0,       // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md
-    'react/jsx-sort-prop-types': 0,  // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-prop-types.md
-    'react/jsx-uses-react': 2,       // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md
-    'react/jsx-uses-vars': 2,        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-vars.md
-    'react/no-did-mount-set-state': [2, 'allow-in-func'], // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-mount-set-state.md
-    'react/no-did-update-set-state': 2, // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md
-    'react/no-multi-comp': 2,        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md
-    'react/no-unknown-property': 2,  // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md
-    'react/prop-types': 2,           // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md
-    'react/react-in-jsx-scope': 2,   // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
-    'react/self-closing-comp': 2,    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md
-    'react/wrap-multilines': 2,      // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md
-    'react/sort-comp': [2, {         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md
-      'order': [
-        'displayName',
-        'propTypes',
-        'contextTypes',
-        'childContextTypes',
-        'mixins',
-        'statics',
-        'defaultProps',
-        'constructor',
-        'getDefaultProps',
-        'getInitialState',
-        'getChildContext',
-        'componentWillMount',
-        'componentDidMount',
-        'componentWillReceiveProps',
-        'shouldComponentUpdate',
-        'componentWillUpdate',
-        'componentDidUpdate',
-        'componentWillUnmount',
-        '/^on.+$/',
-        '/^get.+$/',
-        '/^render.+$/',
-        'render'
-      ]
-    }]
-*/
   }
 };
 
@@ -261,9 +215,9 @@ let version = require('eslint/package.json').version;
 let semver = require('semver');
 
 if (semver.satisfies(version, '>=2.0.0')) {
-  module.exports.rules['keyword-spacing'] = 2;            // http://eslint.org/docs/rules/keyword-spacing
+  module.exports.rules['keyword-spacing'] = 2;            
 } else {
-  module.exports.rules['no-spaced-func'] = 2;             // http://eslint.org/docs/rules/no-spaced-func
-  module.exports.rules['no-trailing-spaces'] = 2;         // http://eslint.org/docs/rules/no-trailing-spaces
-  module.exports.rules['space-return-throw-case'] = 2;    // http://eslint.org/docs/rules/space-return-throw-case
+  module.exports.rules['no-spaced-func'] = 2;             
+  module.exports.rules['no-trailing-spaces'] = 2;         
+  module.exports.rules['space-return-throw-case'] = 2;    
 }

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -31,7 +31,17 @@ module.exports = {
     'jsx': true
   },
 */
+
   'rules': {
+    /**
+     * Values:
+     *  0 = Rule turned off
+     *  1 = Warn
+     *  2 = Error
+     *
+     * See http://eslint.org/docs/user-guide/configuring
+     */
+
     /**
      * Node
      */
@@ -44,12 +54,10 @@ module.exports = {
     //babel inserts 'use strict'; for us
     //'strict': [2, 'never'],          // http://eslint.org/docs/rules/strict
 
-
-
     /**
      * Virtru Specific Rules
      */
-    'virtru-lint/virtru-func-names': 2,
+    'virtru-lint/virtru-func-names': 1,
 
     /**
      * ES6
@@ -94,7 +102,7 @@ module.exports = {
     //'no-sparse-arrays': 2,           // http://eslint.org/docs/rules/no-sparse-arrays
     //'no-unreachable': 2,             // http://eslint.org/docs/rules/no-unreachable
     //'use-isnan': 2,                  // http://eslint.org/docs/rules/use-isnan
-    'valid-jsdoc': [2, {requireReturn: false}],
+    'valid-jsdoc': [1, {requireReturn: false}],
 
     /**
      * Best practices
@@ -174,7 +182,7 @@ module.exports = {
     /*'new-cap': [2, {                 // http://eslint.org/docs/rules/new-cap
       'newIsCap': true
     }],*/
-    'no-multiple-empty-lines': [2, { // http://eslint.org/docs/rules/no-multiple-empty-lines
+    'no-multiple-empty-lines': [1, { // http://eslint.org/docs/rules/no-multiple-empty-lines
       'max': 2
     }],
     //'no-nested-ternary': 2,          // http://eslint.org/docs/rules/no-nested-ternary

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -82,7 +82,7 @@ module.exports = {
       ignoreComments: false
     }],
     'max-statements': [1, 30],
-    'no-multiple-empty-lines': [1, { 
+    'no-multiple-empty-lines': [2, { 
       'max': 2
     }],
     'no-nested-ternary': 2,

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -2,42 +2,25 @@
 
 module.exports = {
   extends: 'airbnb-base/legacy',
+
   env: {                           
     browser: true, // Browser global variables
     node: true, // Node.js global variables and Node.js-specific rules
     es6: true
   },
+
   plugins: [
     'virtru-lint'
   ],
 
-/*@TODO: Decide upon these later
-  'ecmaFeatures': {
-    'arrowFunctions': true,
-    'blockBindings': true,
-    'classes': true,
-    'defaultParams': true,
-    'destructuring': true,
-    'forOf': true,
-    'generators': false,
-    'modules': true,
-    'objectLiteralComputedProperties': true,
-    'objectLiteralDuplicateProperties': false,
-    'objectLiteralShorthandMethods': true,
-    'objectLiteralShorthandProperties': true,
-    'spread': true,
-    'superInFunctions': true,
-    'templateStrings': true,
-    'jsx': true
-  },
-*/
-
-  rules: { // See http://eslint.org/docs/rules/
+  rules: {
     /**
+     * See http://eslint.org/docs/rules/
+     *
      * Values (see http://eslint.org/docs/user-guide/configuring):
      *  0 = Rule turned off
      *  1 = Warn
-     *  2 = Error
+     *  2 = Error (causes non-zero exit code)
      *
      * Docs for a rule, %s, are found at http://eslint.org/docs/rules/%s
      *  Example: http://eslint.org/docs/rules/no-shadow
@@ -49,24 +32,10 @@ module.exports = {
     'global-require': 0,
 
     /**
-     * Strict mode
-     */
-    //@TODO: We aren't using babel at the moment.
-    //babel inserts 'use strict'; for us
-    //'strict': [2, 'never'],          
-
-    /**
      * Virtru Specific Rules
      */
     'virtru-lint/virtru-func-names': 1,
 
-    /**
-     * ES6
-     */
-/*
-    'no-var': 2,                     
-    'prefer-const': 2,               
-*/
     /**
      * Variables
      */
@@ -84,122 +53,42 @@ module.exports = {
      */
     'comma-dangle': [2, 'only-multiline'],    
     'no-cond-assign': [2, 'except-parens'], 
-    //'no-console': 1,                 
     'no-debugger': 1,                
     'no-alert': 2,                   
-    //'no-constant-condition': 1,      
-    //'no-dupe-keys': 2,               
-    //'no-duplicate-case': 2,          
-    //'no-empty': 2,                   
-    //'no-ex-assign': 2,               
     'no-extra-boolean-cast': 2,      
     'no-extra-parens': [2, 'functions'], 
-    //'no-extra-semi': 2,              
-    //'no-func-assign': 2,             
-    //'no-inner-declarations': 2,      
-    //'no-invalid-regexp': 2,          
-    //'no-irregular-whitespace': 2,    
-    //'no-obj-calls': 2,               
-    //'no-sparse-arrays': 2,           
-    //'no-unreachable': 2,             
-    //'use-isnan': 2,                  
     'valid-jsdoc': [1, {requireReturn: false}],
 
     /**
      * Best practices
      */
     'consistent-return': [1, { treatUndefinedAsUnspecified: true}],          
-    //'curly': [2, 'multi-line'],      
-    //'default-case': 2,               
-    /*'dot-notation': [2, {            
-      'allowKeywords': true
-    }],*/
     'eqeqeq': 2,                     
-    //'guard-for-in': 2,               
-    //'no-caller': 2,                  
-    //'no-else-return': 2,             
     'no-eq-null': 2,                 
-    //'no-eval': 2,                    
-    //'no-extend-native': 2,           
-    //'no-extra-bind': 2,              
-    //'no-fallthrough': 2,             
-    //'no-floating-decimal': 2,        
-    //'no-implied-eval': 2,            
-    //'no-lone-blocks': 2,             
-    //'no-loop-func': 2,               
-    //'no-multi-str': 2,               
-    //'no-native-reassign': 2,         
-    //'no-new': 2,                     
-    //'no-new-func': 2,                
-    //'no-new-wrappers': 2,            
-    //'no-octal': 2,                   
-    //'no-octal-escape': 2,            
     'no-param-reassign': 0,          
-    //'no-proto': 2,                   
-    //'no-redeclare': 2,               
-    //'no-return-assign': 2,           
-    //'no-script-url': 2,              
-    //'no-self-compare': 2,            
-    //'no-sequences': 2,               
-    //'no-throw-literal': 2,           
-    //'no-with': 2,                    
-    //'radix': 2,                      
     'vars-on-top': 0,                
     'wrap-iife': [2, 'any'],         
-    //'yoda': 2,                       
 
     /**
      * Style
      */
-    /*'brace-style': [                 
-      2,
-      '1tbs',
-      { 'allowSingleLine': true }
-    ],*/
     'camelcase': [2, {               
       'properties': 'always'
     }],
-    /*'comma-spacing': [2, {           
-      'before': false,
-      'after': true
-    }],*/
-    //'comma-style': [2, 'last'],      
     'eol-last': 0,                   
     'func-names': 0,                 
-    /*'indent': [                      
-      2,
-      2,
-      { 'SwitchCase': 1 }
-    ],*/
-    /*'key-spacing': [2, {             
-        'beforeColon': false,
-        'afterColon': true
-     }],*/
     'max-len': [2, 200, 2, {
       ignoreUrls: true,
       ignoreComments: false
     }],
     'max-statements': [1, 30],
-    /*'new-cap': [2, {                 
-      'newIsCap': true
-    }],*/
     'no-multiple-empty-lines': [1, { 
       'max': 2
     }],
-    //'no-nested-ternary': 2,          
-    //'no-new-object': 2,              
+    'no-nested-ternary': 2,
     'no-underscore-dangle': 0,       
     'object-curly-spacing': [1, 'always'],
-    //'one-var': [2, 'never'],         
     'padded-blocks': [0, 'never'],   
-    /*'quotes': [
-      2, 'single', {avoidEscape: true}    
-    ],*/
-    //'semi': [2, 'always'],           
-    /*'semi-spacing': [2, {            
-      'before': false,
-      'after': true
-    }],*/
     'space-before-function-paren': [2, 'never'], 
     'space-in-parens': [1, 'never'],
     'space-infix-ops': 2,            


### PR DESCRIPTION
In preparation for having better CI/CD infrastructure in place, I think we should start looking at JS linting as a build step, like a unit tests run, that can cause a build to fail.

Some of our repos are too littered with lint for us to be able to enforce no new lint is introduced with new changes, but we do have some that are completely or nearly lint-free. Once a repo is lint-free, we can enable linting as a build step and fail the job if linting fails.

We currently treat almost every violation as an error, which is not an optimal use of a warning/error system and also makes enforcement of linting less feasible. ESLint returns a non-zero exit code if any lint errors are encountered. If there are only warnings, then ESLint returns a `0`. We should set the rule violations that should break builds to be errors and all other rules that we have configured but are not build-breakers to be warnings.